### PR TITLE
more efficiently load audio

### DIFF
--- a/whisperspeech/pipeline.py
+++ b/whisperspeech/pipeline.py
@@ -70,9 +70,14 @@ class Pipeline:
             self.encoder = EncoderClassifier.from_hparams("speechbrain/spkrec-ecapa-voxceleb",
                                                           savedir="~/.cache/speechbrain/",
                                                           run_opts={"device": "cuda"})
-        samples, sr = torchaudio.load(fname)
-        samples = self.encoder.audio_normalizer(samples[0,:30*sr], sr)
-        spk_emb = self.encoder.encode_batch(samples)
+        audio_info = torchaudio.info(fname)
+        actual_sample_rate = audio_info.sample_rate
+        num_frames = actual_sample_rate * 30  # specify 30 seconds worth of frames
+        samples, sr = torchaudio.load(fname, num_frames=num_frames)
+        samples = samples[:, :num_frames]
+        samples = self.encoder.audio_normalizer(samples[0], sr).to(self.compute_device)
+        spk_emb = self.encoder.encode_batch(samples.unsqueeze(0))
+
         return spk_emb[0,0]
         
     def generate_atoks(self, text, speaker=None, lang='en', cps=15, step_callback=None):

--- a/whisperspeech/pipeline.py
+++ b/whisperspeech/pipeline.py
@@ -75,7 +75,7 @@ class Pipeline:
         num_frames = actual_sample_rate * 30  # specify 30 seconds worth of frames
         samples, sr = torchaudio.load(fname, num_frames=num_frames)
         samples = samples[:, :num_frames]
-        samples = self.encoder.audio_normalizer(samples[0], sr).to(self.compute_device)
+        samples = self.encoder.audio_normalizer(samples[0], sr)
         spk_emb = self.encoder.encode_batch(samples.unsqueeze(0))
 
         return spk_emb[0,0]


### PR DESCRIPTION
Calculates 30 seconds worth of frames based on the sampling rate and only extracts that amount.  Important if trying to load a relatively large audio file.  30 can be changed of course and the script adapts dynamically.  No longer have to load the entire audio file.