### PR TITLE
possibly more efficient kv

### DIFF
--- a/whisperspeech/modules.py
+++ b/whisperspeech/modules.py
@@ -76,6 +76,9 @@ class MultiHeadAttention(nn.Module):
         self.qkv = None
         self.kv = None
 
+        # track ID of the last kvx processed
+        self.cached_kvx_id = None
+
     def setup_kv_cache(self, max_batch_size, max_seq_len, dtype=torch.float32):
         cache_shape = (max_batch_size, self.n_head, max_seq_len, self.n_state//self.n_head)
         self.k_cache = torch.zeros(cache_shape, dtype=dtype, device=self.key.weight.device)
@@ -117,28 +120,37 @@ class MultiHeadAttention(nn.Module):
         causal = False,
         mask=None,
     ):
-        if self.qkv:
+        # Generate a unique identifier for kvx to check if it has changed
             q,k,v = self.qkv(qx).split(self.odim, dim=-1)
+        current_kvx_id = id(kvx)
         elif self.kv:
-            q = self.q(qx)
-            k,v = self.kv(kvx).split(self.odim, dim=-1)
-        else:
-            q,k,v = None,None,None
-        
-        if q is None: q = self.query(qx) * self.sqrt_qk_scale
-        q = self.split_heads(q, q_positions, rope = self.rotary, subsampling = self.query_subsampling)
 
-        if kvx is not self.cached_kvx:
-            if k is None: k = self.key(kvx) * self.sqrt_qk_scale
-            k = self.split_heads(k, kv_positions, rope = self.rotary, subsampling = self.key_subsampling)
-            if v is None: v = self.value(kvx)
+            q = self.q(qx)
+        # Check if the input kvx has changed since the last computation
+            k,v = self.kv(kvx).split(self.odim, dim=-1)
+        if self.cached_kvx_id != current_kvx_id:
+        else:
+            # recompute if input kvx has changed
+            q,k,v = None,None,None
+            k = self.key(kvx) * self.sqrt_qk_scale
+
+            k = self.split_heads(k, kv_positions, rope=self.rotary, subsampling=self.key_subsampling)
+        if q is None: q = self.query(qx) * self.sqrt_qk_scale
+            v = self.value(kvx)
             v = self.split_heads(v, kv_positions)
             if self.k_cache is not None:
-                self.k_cache[:k.shape[0],:,kv_positions] = k
-                self.v_cache[:v.shape[0],:,kv_positions] = v
+                self.k_cache[:k.shape[0], :, kv_positions] = k
+                self.v_cache[:v.shape[0], :, kv_positions] = v
 
-        if self.k_cache is not None:
-            k, v = self.k_cache[:k.shape[0]], self.v_cache[:v.shape[0]]
+            # Update cached_kvx_id
+            self.cached_kvx_id = current_kvx_id
+        else:
+            # nput kvx has not changed, use the cached keys and values
+            k = self.k_cache[:kvx.shape[0]]
+            v = self.v_cache[:kvx.shape[0]]
+
+        q = self.query(qx) * self.sqrt_qk_scale
+        q = self.split_heads(q, q_positions, rope=self.rotary, subsampling=self.query_subsampling)
 
         if mask is not None:
             mask = mask[q_positions]


### PR DESCRIPTION
RESUBMITTING due to github issues...sorry about that, but here it is again for a discussion.  Here was you original response to the prior pull request for the record:



_**Hey,

Making a line-by-line review is tricky on my phone but I’ll try to provide some more context.

This code is a little tricky since there are multiple pathways through it, depending on the layer of the network where it is used. First we have merged qkv or kv layers to avoid calculating three separate linear layers and do a single bigger linear once instead (it’s a very common optimization for LLMs but here it is a bit more involved because we have to support both self- and cross-attention). Second there is the cache which gets updated all at once for cross- and token-by-token for self-attention.

For self-attention we use the merged qkv linear layer; with the cache enabled the kvx is the same as qx (last token) so we need to update the cache and fetch the kv for all the already generated tokens from it. For cross-attention kvx stays constant throughout multiple iterations in a single generate call so we can cache the kv calculation (but not q) once and then reuse.

I really should write some simplified test cases for this code (like I did for FlexEmbeddings).

I think you are right that we are calculating too much here but I believe it’s only for the cross-attention case with the merged kv layer enabled. Nevertheless (and a bit surprisingly) merging still showed a modest overall performance improvement on CUDA in my tests so I think we should strive to keep the q,k,v layer merging.

Let me know if this makes sense and if you have further questions.**_
