### PR TITLE
Fix to ensure cross-platform compatibility for storing in the cache folder

### DIFF
--- a/nbs/0. Download models.ipynb
+++ b/nbs/0. Download models.ipynb
@@ -18,6 +18,7 @@
    "outputs": [],
    "source": [
     "#| exporti\n",
+    "from os.path import expanduser\n",
     "from fastcore.script import call_parse\n",
     "import whisperx\n",
     "import whisper\n",
@@ -62,7 +63,7 @@
     "    whisperx.vad.load_vad_model('cpu')\n",
     "    load_whisperx('medium.en', 'en')\n",
     "    load_whisperx('medium', 'en')\n",
-    "    EncoderClassifier.from_hparams(source=\"speechbrain/spkrec-ecapa-voxceleb\", savedir=\"~/.cache/speechbrain/\")"
+    "    EncoderClassifier.from_hparams(source=\"speechbrain/spkrec-ecapa-voxceleb\", savedir=expanduser(\"~/.cache/speechbrain/\"))"
    ]
   }
  ],

--- a/nbs/2A. Speaker Embeddings.ipynb
+++ b/nbs/2A. Speaker Embeddings.ipynb
@@ -163,7 +163,7 @@
    "outputs": [],
    "source": [
     "classifier = EncoderClassifier.from_hparams(\"speechbrain/spkrec-ecapa-voxceleb\",\n",
-    "                                            savedir=\"~/.cache/speechbrain/\",\n",
+    "                                            savedir=os.path.expanduser(\"~/.cache/speechbrain/\"),\n",
     "                                            run_opts={\"device\": \"cuda\"})"
    ]
   },

--- a/nbs/7. Pipeline.ipynb
+++ b/nbs/7. Pipeline.ipynb
@@ -18,6 +18,7 @@
    "outputs": [],
    "source": [
     "#| exporti\n",
+    "from os.path import expanduser\n",
     "import torch\n",
     "from .t2s_up_wds_mlang_enclm import TSARTransformer\n",
     "from .s2a_delar_mup_wds_mlang import SADelARTransformer\n",
@@ -96,7 +97,7 @@
     "            if device == 'mps': device = 'cpu' # operator 'aten::_fft_r2c' is not currently implemented for the MPS device\n",
     "            from speechbrain.pretrained import EncoderClassifier\n",
     "            self.encoder = EncoderClassifier.from_hparams(\"speechbrain/spkrec-ecapa-voxceleb\",\n",
-    "                                                          savedir=\"~/.cache/speechbrain/\",\n",
+    "                                                          savedir=expanduser(\"~/.cache/speechbrain/\"),\n",
     "                                                          run_opts={\"device\": device})\n",
     "        audio_info = torchaudio.info(fname)\n",
     "        actual_sample_rate = audio_info.sample_rate\n",

--- a/whisperspeech/extract_spk_emb.py
+++ b/whisperspeech/extract_spk_emb.py
@@ -5,6 +5,7 @@ __all__ = []
 
 # %% ../nbs/2A. Speaker Embeddings.ipynb 3
 import os
+from os.path import expanduser
 import sys
 
 from fastprogress import progress_bar
@@ -48,7 +49,7 @@ def process_shard(
     dl = chunked_dataset(input, bs=batch_size)
     
     classifier = EncoderClassifier.from_hparams("speechbrain/spkrec-ecapa-voxceleb",
-                                                savedir=f"{os.environ['HOME']}/.cache/speechbrain/",
+                                                savedir=expanduser("~/.cache/speechbrain/"),
                                                 run_opts = {"device": device})
     
     with utils.AtomicTarWriter(utils.derived_name(input, f'spk_emb')) as sink:

--- a/whisperspeech/extract_stoks.py
+++ b/whisperspeech/extract_stoks.py
@@ -6,6 +6,7 @@ __all__ = []
 # %% ../nbs/3B. Semantic token extraction.ipynb 2
 import sys
 import os
+from os.path import expanduser
 import itertools
 from pathlib import Path
 
@@ -40,7 +41,7 @@ def prepare_stoks(
 #     vq_model.encode_mel = torch.compile(vq_model.encode_mel, mode="reduce-overhead", fullgraph=True)
     
     spk_classifier = EncoderClassifier.from_hparams("speechbrain/spkrec-ecapa-voxceleb",
-                                                    savedir=f"{os.environ['HOME']}/.cache/speechbrain/",
+                                                    savedir=expanduser("~/.cache/speechbrain/"),
                                                     run_opts = {"device": device})
     
     total = n_samples//batch_size if n_samples else 'noinfer'

--- a/whisperspeech/fetch_models.py
+++ b/whisperspeech/fetch_models.py
@@ -8,6 +8,7 @@ from fastcore.script import call_parse
 import whisperx
 import whisper
 from speechbrain.pretrained import EncoderClassifier
+from os.path import expanduser
 
 # %% ../nbs/0. Download models.ipynb 3
 def load_whisperx(model, lang):
@@ -25,4 +26,4 @@ def main():
     whisperx.vad.load_vad_model('cpu')
     load_whisperx('medium.en', 'en')
     load_whisperx('medium', 'en')
-    EncoderClassifier.from_hparams(source="speechbrain/spkrec-ecapa-voxceleb", savedir="~/.cache/speechbrain/")
+    EncoderClassifier.from_hparams(source="speechbrain/spkrec-ecapa-voxceleb", savedir=expanduser("~/.cache/speechbrain/"))

--- a/whisperspeech/pipeline.py
+++ b/whisperspeech/pipeline.py
@@ -4,6 +4,7 @@
 __all__ = ['Pipeline']
 
 # %% ../nbs/7. Pipeline.ipynb 1
+import os
 import torch
 from .t2s_up_wds_mlang_enclm import TSARTransformer
 from .s2a_delar_mup_wds_mlang import SADelARTransformer
@@ -74,7 +75,7 @@ class Pipeline:
             if device == 'mps': device = 'cpu' # operator 'aten::_fft_r2c' is not currently implemented for the MPS device
             from speechbrain.pretrained import EncoderClassifier
             self.encoder = EncoderClassifier.from_hparams("speechbrain/spkrec-ecapa-voxceleb",
-                                                          savedir="~/.cache/speechbrain/",
+                                                          savedir = os.path.expanduser("~/.cache/speechbrain/"),
                                                           run_opts={"device": device})
         audio_info = torchaudio.info(fname)
         actual_sample_rate = audio_info.sample_rate

--- a/whisperspeech/pipeline.py
+++ b/whisperspeech/pipeline.py
@@ -4,7 +4,7 @@
 __all__ = ['Pipeline']
 
 # %% ../nbs/7. Pipeline.ipynb 1
-import os
+from os.path import expanduser
 import torch
 from .t2s_up_wds_mlang_enclm import TSARTransformer
 from .s2a_delar_mup_wds_mlang import SADelARTransformer
@@ -75,7 +75,7 @@ class Pipeline:
             if device == 'mps': device = 'cpu' # operator 'aten::_fft_r2c' is not currently implemented for the MPS device
             from speechbrain.pretrained import EncoderClassifier
             self.encoder = EncoderClassifier.from_hparams("speechbrain/spkrec-ecapa-voxceleb",
-                                                          savedir = os.path.expanduser("~/.cache/speechbrain/"),
+                                                          savedir = expanduser("~/.cache/speechbrain/"),
                                                           run_opts={"device": device})
         audio_info = torchaudio.info(fname)
         actual_sample_rate = audio_info.sample_rate


### PR DESCRIPTION
This is a minor update to fix the case where `~` is not recognized as the user home directory.  Referencing the python [documentation](https://docs.python.org/3/library/os.path.html) "Unlike a Unix shell, Python does not do any automatic path expansions. Functions such as expanduser() and expandvars() can be invoked explicitly when an application desires shell-like path expansion."  This fix ensures cross-platform compatability for storing and loading items in the hidden cache folder of the home directory.