### PR TITLE
S2A: Start generation at earlier location when given a prompt

### DIFF
--- a/whisperspeech/s2a_delar_mup_wds_mlang.py
+++ b/whisperspeech/s2a_delar_mup_wds_mlang.py
@@ -496,6 +496,7 @@ class SADelARTransformer(nn.Module):
             start = atoks_prompt.shape[-1]
             for i in range(self.quantizers):
                 toks[:,i,1+i:start+i+1] = atoks_prompt[:,i]
+            start = max(0, start - self.quantizers)
         it = range(start+1,min(N,self.ctx_n-1))
         if show_progress_bar: it = progress_bar(it)
         with record_function("encode"):


### PR DESCRIPTION
Currently, from my understanding, when given an atok prompt, generation starts after the end of the prompt. This might be slightly suboptimal because that way values like `[<normal atok>, <eos>, <eos>, <eos>]` are passed to the model in the middle of the sequence, which might throw it off. This can be avoided by starting generation at a slightly earlier point.