### PR TITLE
Migrate torch.cuda.amp.GradScaler to torch.amp

### DIFF
--- a/whisperspeech/train.py
+++ b/whisperspeech/train.py
@@ -20,6 +20,10 @@ import IPython
 
 import torch
 import torch.nn as nn
+try:  # torch >= 2.3
+    from torch.amp import GradScaler
+except ImportError:  # torch < 2.3
+    from torch.cuda.amp import GradScaler
 from torch.utils.data.dataloader import DataLoader
 from torch.profiler import record_function
 from whisperspeech import utils
@@ -180,7 +184,7 @@ def train(checkpoint_path, model, train, val, half=True, bs=16, lr=1e-4, drop_la
 
         optimizer = torch.optim.AdamW(lr=lr, betas=(0.9, 0.95), fused=device!='cpu', params=groups)
         model._optimizer = optimizer
-        scaler = torch.cuda.amp.GradScaler(enabled=half)
+        scaler = GradScaler(enabled=half)
         
         if lr_schedule == 'cosine':
             lr_scheduler = torch.optim.lr_scheduler.OneCycleLR(


### PR DESCRIPTION
Fixes #176

### Summary

`torch.cuda.amp.GradScaler` has been deprecated since torch 2.3 and is scheduled for removal. This PR migrates the lone remaining `torch.cuda.amp` reference in [whisperspeech/train.py:183](https://github.com/WhisperSpeech/WhisperSpeech/blob/main/whisperspeech/train.py#L183) to the `torch.amp` API **without raising the torch floor** (settings.ini declares `torch>=2`, which predates `torch.amp.GradScaler` — added in 2.3):

```python
try:  # torch >= 2.3
    from torch.amp import GradScaler
except ImportError:  # torch < 2.3
    from torch.cuda.amp import GradScaler
```

```diff
-        scaler = torch.amp.GradScaler("cuda", enabled=half)
+        scaler = GradScaler(enabled=half)
```

`torch.amp.GradScaler()` defaults `device` to `"cuda"`, so this is exactly equivalent to the old call. The file already uses the new-style API elsewhere (lines 105/235/257 use `torch.autocast(device_type=device, ...)`, and the package uses `torch.compile` throughout), so this line was the only inconsistent spot.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Validation

Verified on torch 2.11.0 with `warnings.simplefilter("error", FutureWarning)`:

- `torch.amp.GradScaler(enabled=False)` constructs warning-free (AMP is disabled when CUDA is unavailable, by design).
- Fallback branch reachability: with `torch.amp` masked (simulating torch < 2.3), the `ImportError` is raised and the import falls through to `torch.cuda.amp.GradScaler` (the old API emits no warning before torch 2.3).
- Control group: `torch.cuda.amp.GradScaler(enabled=True)` raises `FutureWarning` under the same filter — the fix is effective and the filter is sensitive.
- `py_compile` passes; the repo has zero bare `torch.cuda.amp` references (grep-verified).

### User impact

No behavior change on any supported torch version (the declared `torch>=2` floor is preserved); the `FutureWarning` emitted by every `--half` training run on torch 2.4+ is eliminated, as is the breakage risk once `torch.cuda.amp` is removed.

### Notes for reviewers

- `torch.amp.GradScaler("cuda")` and `torch.cuda.amp.GradScaler()` share the same methods and state-dict/checkpoint format.
- Same migration as [ultralytics/yolov5#13244](https://github.com/ultralytics/yolov5/pull/13244) and [huggingface/lerobot#3167](https://github.com/huggingface/lerobot/pull/3167).
